### PR TITLE
add plugins block in anticipation of removal of modules/build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils;
 
+plugins {
+    id 'org.labkey.build.module'
+}
+
 dependencies {
     implementation "com.sun.mail:jakarta.mail:${javaMailVersion}"
     external "org.mybatis:mybatis:${mybatisVersion}"
@@ -23,7 +27,6 @@ dependencies {
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "core"), depProjectConfig: "apiJarFile")
 }
 
-// TODO move resources files into resources directory to avoid this overlap
 sourceSets {
     main {
         resources {


### PR DESCRIPTION
#### Rationale
We plan to remove the `server/modules/build.gradle` file that has logic to apply plugins for subprojects since that logic is only a heuristic and fails to do the right thing for file-based modules that include only client source code.  Instead, we will update each module's own `build.gradle` file so it applies the appropriate plugins (and add `build.gradle` files where there are none).  

#### Changes
* apply module plugin in build.gradle file
