### PR TITLE
JavaScriptDisplayColumn no longer renders inline event handlers

### DIFF
--- a/src/org/labkey/workflow/query/WorkflowQuerySchema.java
+++ b/src/org/labkey/workflow/query/WorkflowQuerySchema.java
@@ -254,8 +254,8 @@ public class WorkflowQuerySchema extends UserSchema
         public DisplayColumn createRenderer(ColumnInfo colInfo)
         {
             Collection<String> dependencies = Collections.singletonList("workflow/view/reassignTask.js");
-            String javaScriptEvent = "onclick=\"createReassignTaskWindow(${id_:jsString}, ${assignee_:jsString});\"";
-            return new JavaScriptDisplayColumn(colInfo, dependencies, javaScriptEvent, "labkey-text-link")
+            String onClickJavaScript = "createReassignTaskWindow(${id_:jsString}, ${assignee_:jsString});";
+            return new JavaScriptDisplayColumn(colInfo, dependencies, onClickJavaScript, "labkey-text-link")
             {
                 @NotNull
                 @Override


### PR DESCRIPTION
#### Rationale
Adjust based on change to `JavaScriptDisplayColumn`

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4970