### PR TITLE
Close Activiti ProcessEngine when server shuts down

### DIFF
--- a/src/org/labkey/workflow/WorkflowManager.java
+++ b/src/org/labkey/workflow/WorkflowManager.java
@@ -139,7 +139,7 @@ public class WorkflowManager implements WorkflowService
             @Override
             public String getName()
             {
-                return "WorkflowManager shutdown";
+                return "WorkflowManager process engine";
             }
 
             @Override

--- a/src/org/labkey/workflow/WorkflowManager.java
+++ b/src/org/labkey/workflow/WorkflowManager.java
@@ -83,7 +83,9 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.test.TestWhen;
+import org.labkey.api.util.ContextListener;
 import org.labkey.api.util.Path;
+import org.labkey.api.util.ShutdownListener;
 import org.labkey.api.util.TestContext;
 import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.ViewContext;
@@ -130,6 +132,35 @@ public class WorkflowManager implements WorkflowService
     private WorkflowManager()
     {
         // prevent external construction with a private default constructor
+
+        // Don't leave activiti ProcessEngine running with an invalid data source
+        ContextListener.addShutdownListener(new ShutdownListener()
+        {
+            @Override
+            public String getName()
+            {
+                return "WorkflowManager shutdown";
+            }
+
+            @Override
+            public void shutdownPre()
+            {
+                if (_processEngine != null)
+                {
+                    try
+                    {
+                        _processEngine.close();
+                    }
+                    finally
+                    {
+                        _processEngine = null;
+                    }
+                }
+            }
+
+            @Override
+            public void shutdownStarted() { /* Nothing to do */ }
+        });
     }
 
     public static WorkflowManager get()
@@ -283,7 +314,7 @@ public class WorkflowManager implements WorkflowService
      * finds the workflow process with that process variable value that was started last.
      * @param key the name of the process variable
      * @param valueField the field in the act_hi_varinst table in which the value is stored
-     * @param sqlValue the string representation of the comparison value to be used in the SQL statement (e.g., for a string
+     * @param value the string representation of the comparison value to be used in the SQL statement (e.g., for a string
      *                 value, this should contain the single quotes ('string'), but for an integer value it should not (123))
      * @param container the container context
      * @return the lates workflow instance with a variable with the given name and value
@@ -1132,7 +1163,7 @@ public class WorkflowManager implements WorkflowService
         return getProcessEngine().getFormService();
     }
 
-    private ProcessEngine getProcessEngine()
+    private synchronized ProcessEngine getProcessEngine()
     {
         if (_processEngine == null)
         {


### PR DESCRIPTION
#### Rationale
When a deployApp triggers a server refresh, the `WorkflowManager._processEngine` can be left initialized with an invalid data source. This causes activiti to flood the server log with errors:
```
ERROR AcquireTimerJobsRunnable 2024-10-16T13:42:31,420                Thread-39 : exception during timer job acquisition: org/apache/ibatis/exceptions/ExceptionFactory
java.lang.NoClassDefFoundError: org/apache/ibatis/exceptions/ExceptionFactory
	at org.apache.ibatis.session.defaults.DefaultSqlSession.selectList(DefaultSqlSession.java:156) ~[mybatis-3.5.13.jar:3.5.13]
	at org.apache.ibatis.session.defaults.DefaultSqlSession.selectList(DefaultSqlSession.java:147) ~[mybatis-3.5.13.jar:3.5.13]
	at org.apache.ibatis.session.defaults.DefaultSqlSession.selectList(DefaultSqlSession.java:142) ~[mybatis-3.5.13.jar:3.5.13]
	at org.activiti.engine.impl.db.DbSqlSession.selectListWithRawParameter(DbSqlSession.java:443) ~[activiti-engine-5.20.0.jar:5.20.0]
	at org.activiti.engine.impl.db.DbSqlSession.selectList(DbSqlSession.java:434) ~[activiti-engine-5.20.0.jar:5.20.0]
	at org.activiti.engine.impl.db.DbSqlSession.selectList(DbSqlSession.java:429) ~[activiti-engine-5.20.0.jar:5.20.0]
	at org.activiti.engine.impl.db.DbSqlSession.selectList(DbSqlSession.java:412) ~[activiti-engine-5.20.0.jar:5.20.0]
	at org.activiti.engine.impl.persistence.entity.JobEntityManager.findNextTimerJobsToExecute(JobEntityManager.java:157) ~[activiti-engine-5.20.0.jar:5.20.0]
	at org.activiti.engine.impl.cmd.AcquireTimerJobsCmd.execute(AcquireTimerJobsCmd.java:45) ~[activiti-engine-5.20.0.jar:5.20.0]
	at org.activiti.engine.impl.cmd.AcquireTimerJobsCmd.execute(AcquireTimerJobsCmd.java:29) ~[activiti-engine-5.20.0.jar:5.20.0]
	at org.activiti.engine.impl.interceptor.CommandInvoker.execute(CommandInvoker.java:24) ~[activiti-engine-5.20.0.jar:5.20.0]
	at org.activiti.engine.impl.interceptor.CommandContextInterceptor.execute(CommandContextInterceptor.java:57) ~[activiti-engine-5.20.0.jar:5.20.0]
	at org.activiti.engine.impl.interceptor.LogInterceptor.execute(LogInterceptor.java:31) ~[activiti-engine-5.20.0.jar:5.20.0]
	at org.activiti.engine.impl.cfg.CommandExecutorImpl.execute(CommandExecutorImpl.java:40) ~[activiti-engine-5.20.0.jar:5.20.0]
	at org.activiti.engine.impl.cfg.CommandExecutorImpl.execute(CommandExecutorImpl.java:35) ~[activiti-engine-5.20.0.jar:5.20.0]
	at org.activiti.engine.impl.asyncexecutor.AcquireTimerJobsRunnable.run(AcquireTimerJobsRunnable.java:52) [activiti-engine-5.20.0.jar:5.20.0]
	at java.base/java.lang.Thread.run(Thread.java:840) [?:?]
Caused by: java.lang.ClassNotFoundException: Illegal access: this web application instance has been stopped already. Could not load [org.apache.ibatis.exceptions.ExceptionFactory]. The following stack trace is thrown for debugging purposes as well as to attempt to terminate the thread which caused the illegal access.
	... 17 more
```

#### Related Pull Requests
* N/A

#### Changes
* Add a `ShutdownListener` to clean up `WorkflowManager._processEngine`
