### PR TITLE
Mark NLP-related modules as PostgreSQL-only

### DIFF
--- a/module.properties
+++ b/module.properties
@@ -8,3 +8,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: pgsql


### PR DESCRIPTION
#### Rationale
Module no longer needs to support SQL Server